### PR TITLE
Fix initials sanitization and update test

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -78,8 +78,20 @@ app.post('/api/highscores', (req, res) => {
         return res.status(400).json({ error: 'Score out of valid range' });
     }
     
-    // Sanitize initials (only allow A-Z and limit to 3 characters)
-    const sanitizedInitials = initials.replace(/[^A-Z]/g, '').substring(0, 3);
+    // Sanitize initials
+    // 1. Convert to upper case so lowercase letters are accepted
+    // 2. Remove any characters outside A-Z
+    // 3. Limit to the first 3 characters
+    const sanitizedInitials = (initials || '')
+        .toUpperCase()
+        .replace(/[^A-Z]/g, '')
+        .substring(0, 3);
+
+    // Ensure we still have at least one valid character after sanitising
+    if (!sanitizedInitials) {
+        console.log('Validation failed: initials contain no valid characters');
+        return res.status(400).json({ error: 'Invalid initials' });
+    }
     
     // Add new score with timestamp
     const newScore = { 

--- a/server/test-highscores.js
+++ b/server/test-highscores.js
@@ -11,7 +11,9 @@ const fetch = require('node-fetch');
 
 const API_URL = 'http://localhost:3000/api/highscores';
 const TEST_SCORE = {
-    initials: 'TST',
+    // Use lowercase initials to verify that the server correctly
+    // sanitizes and uppercases incoming values
+    initials: 'tst',
     score: Math.floor(Math.random() * 5000) + 1000, // Random score between 1000-6000
     gameData: {
         level: 3,
@@ -19,6 +21,10 @@ const TEST_SCORE = {
         timePlayed: 120000 // 2 minutes
     }
 };
+
+// The server converts initials to uppercase and strips non A-Z characters.
+// Replicate that logic here so we know what to look for in the response.
+const EXPECTED_INITIALS = TEST_SCORE.initials.toUpperCase().replace(/[^A-Z]/g, '').substring(0, 3);
 
 async function testHighScoreAPI() {
     try {
@@ -71,8 +77,8 @@ async function testHighScoreAPI() {
         console.log(`   Retrieved ${updatedScores.length} high scores`);
         
         // Find our test score
-        const foundScore = updatedScores.find(score => 
-            score.initials === TEST_SCORE.initials && 
+        const foundScore = updatedScores.find(score =>
+            score.initials === EXPECTED_INITIALS &&
             score.score === TEST_SCORE.score
         );
         


### PR DESCRIPTION
## Summary
- sanitize incoming initials more robustly on the server
- reject scores with invalid initials
- adjust high score test to verify case-insensitive initials handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b29d9b988324bbabfe2c2e28e3fb