### PR TITLE
Move high score cooldown variable

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -525,6 +525,7 @@ let lastScoreSubmitTime = 0;
 // Near the top of the file, add a variable to store the high score
 // ... existing code ...
 let pendingHighScore = 0; // Add this variable to store the score for high score submission
+let highScoreSubmitCooldown = 0;
 
 // ... rest of the existing code ...
 
@@ -4419,9 +4420,6 @@ function drawLevelAnnouncement() {
         ctx.restore();
     }
 }
-
-// Add a cooldown variable near the top of your file with other game state variables
-let highScoreSubmitCooldown = 0;
 
 // Remove the transition state variable since we're using a simpler approach
 


### PR DESCRIPTION
## Summary
- move `highScoreSubmitCooldown` near other game state variables
- delete stale comment at the old location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b76f38a08324819c8d5951aca15f